### PR TITLE
docs: add contributing guide and style guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,202 @@
+# Contributing Guide
+
+## Table of Contents
+1. [Getting Started](#getting-started)
+2. [Branch Naming](#branch-naming)
+3. [Commit Messages](#commit-messages)
+4. [Pull Requests](#pull-requests)
+5. [Code Review](#code-review)
+6. [Testing Requirements](#testing-requirements)
+7. [Definition of Done](#definition-of-done)
+
+---
+
+## Getting Started
+
+1. Clone the repository and install dependencies:
+   ```bash
+   git clone <repo-url>
+   cd event-management-system
+
+   # Frontend
+   cd frontend && npm install
+
+   # Backend (restore packages)
+   cd ../backend && dotnet restore
+   ```
+2. Copy environment files and fill in secrets:
+   ```bash
+   cp frontend/.env.example frontend/.env
+   cp backend/EventManagement/appsettings.Development.json.example backend/EventManagement/appsettings.Development.json
+   ```
+3. Make sure all existing tests pass before you start:
+   ```bash
+   cd backend && dotnet test
+   ```
+
+---
+
+## Branch Naming
+
+Branches **must** follow this pattern:
+
+```
+<type>/<short-description>
+```
+
+| Type | When to use |
+|---|---|
+| `feat` | New feature or user-facing capability |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code restructure with no behaviour change |
+| `test` | Adding or updating tests only |
+| `chore` | Build scripts, dependencies, tooling, CI |
+| `style` | Formatting / whitespace only (no logic changes) |
+
+**Rules:**
+- Use **kebab-case** for the description (`feat/add-waitlist-notifications`, not `feat/AddWaitlistNotifications`).
+- Keep descriptions short — 3–5 words max.
+- Always branch off the latest `main`.
+
+**Examples:**
+```
+feat/qr-check-in-scanner
+fix/booking-cancellation-deadline
+docs/api-authentication
+refactor/loyalty-tier-calculation
+test/admin-controller-coverage
+chore/upgrade-ef-core-9
+```
+
+---
+
+## Commit Messages
+
+Follow the **Conventional Commits** specification.
+
+```
+<type>(<optional scope>): <short summary>
+
+<optional body — explain WHY, not WHAT>
+
+<optional footer — breaking changes, issue refs>
+```
+
+**Rules:**
+- Summary line: imperative mood, no capital first letter, no trailing period, ≤ 72 characters.
+- Body: wrap at 72 characters, explain the motivation and contrast with prior behaviour.
+- Use `BREAKING CHANGE:` in the footer when a public API or DB schema changes in a non-backwards-compatible way.
+
+**Examples:**
+```
+feat(bookings): enforce 7-day cancellation window
+
+Attendees can no longer cancel within 7 days of the event start time
+unless the event itself was cancelled. This protects organiser revenue.
+
+fix(auth): return 401 instead of 500 on expired JWT
+
+refactor(events): extract visibility filter into helper method
+
+chore: upgrade xUnit to 2.9 and fix test runner warnings
+```
+
+---
+
+## Pull Requests
+
+### Before Opening
+
+- [ ] Branch is up to date with `main` (`git pull --rebase origin main`).
+- [ ] All tests pass locally (`dotnet test`).
+- [ ] New code has accompanying tests (see [Testing Requirements](#testing-requirements)).
+- [ ] No debug code, commented-out blocks, or `TODO`s left in the diff.
+
+### Title
+
+Use the same format as a commit message summary:
+
+```
+feat(organizers): add subscriber count to public profile
+fix(bookings): prevent double-booking on concurrent requests
+```
+
+### Description Template
+
+```markdown
+## What
+<!-- One paragraph describing what changed. -->
+
+## Why
+<!-- The motivation — link to a user story, bug report, or design decision. -->
+
+## How
+<!-- Brief notes on the approach taken, especially non-obvious decisions. -->
+
+## Testing
+<!-- What tests were added or updated, and how to verify manually if needed. -->
+
+## Checklist
+- [ ] Tests added / updated
+- [ ] Docs updated (if behaviour or API changed)
+- [ ] No breaking changes (or BREAKING CHANGE footer added to commit)
+```
+
+### Size
+
+- Keep PRs focused. One logical change per PR.
+- If a PR exceeds ~400 lines of meaningful diff, consider splitting it.
+
+---
+
+## Code Review
+
+### As an Author
+
+- Respond to all review comments — either address them or explain why you disagree.
+- Mark resolved threads as resolved only after you have made the change.
+- Do not force-push once a review is in progress unless explicitly agreed.
+
+### As a Reviewer
+
+- Approve only when you are confident the change is correct, tested, and consistent with the style guide.
+- Use the following prefixes in comments to signal intent:
+  - **`nit:`** — minor style preference, not blocking.
+  - **`question:`** — seeking understanding, not necessarily requesting a change.
+  - **`suggestion:`** — optional improvement.
+  - *(No prefix)* — blocking issue that must be resolved before merge.
+- At least **one approval** is required before merging.
+- The author should not merge their own PR unless explicitly permitted for a hotfix.
+
+---
+
+## Testing Requirements
+
+All new features and bug fixes **must** ship with tests. See [ARCHITECTURE.md](ARCHITECTURE.md) for the overall testing strategy and the `backend/EventManagement.Tests/` project for patterns.
+
+| Change type | Required test |
+|---|---|
+| New API endpoint | Integration test via `WebApplicationFactory` |
+| New business rule | Integration test covering both happy path and violation |
+| Bug fix | Regression test that would have failed before the fix |
+| Pure logic / utility | Unit test |
+| Frontend component | — (Vitest / RTL tests welcomed but not yet mandatory) |
+
+Run the full test suite before pushing:
+```bash
+cd backend && dotnet test --logger "console;verbosity=normal"
+```
+
+---
+
+## Definition of Done
+
+A task is considered complete when **all** of the following are true:
+
+- [ ] Feature works end-to-end against the local dev environment.
+- [ ] All existing tests pass.
+- [ ] New tests cover the added behaviour.
+- [ ] Relevant documentation in `docs/` is updated (API reference, architecture, etc.).
+- [ ] PR has been reviewed and approved.
+- [ ] Branch is merged into `main` and the feature branch deleted.

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,0 +1,257 @@
+# Style Guide
+
+Conventions for both the **ASP.NET Core backend** (C#) and the **React frontend** (TypeScript). Follow these to keep the codebase consistent across contributors.
+
+## Table of Contents
+1. [General Principles](#general-principles)
+2. [Backend — C#](#backend--c)
+   - [Naming](#naming-c)
+   - [File & Folder Layout](#file--folder-layout)
+   - [Controllers](#controllers)
+   - [DTOs](#dtos)
+   - [Models](#models)
+   - [Services](#services)
+   - [Tests](#tests-backend)
+3. [Frontend — TypeScript / React](#frontend--typescript--react)
+   - [Naming](#naming-ts)
+   - [File & Folder Layout](#file--folder-layout-1)
+   - [Components](#components)
+   - [API Layer](#api-layer)
+   - [State Management](#state-management)
+   - [Styling](#styling)
+   - [Types](#types)
+4. [Shared — Git & Files](#shared--git--files)
+
+---
+
+## General Principles
+
+- **Consistency over preference.** Match the patterns already in the file you are editing before introducing a new one.
+- **Explicit over implicit.** Name things for what they are, not where they live.
+- **Minimal surface area.** Only export what must be public. Only add abstraction when it is needed at least twice.
+- **Fail loudly.** Prefer exceptions / error responses over silent fallbacks.
+
+---
+
+## Backend — C#
+
+### Naming (C#)
+
+| Construct | Convention | Example |
+|---|---|---|
+| Namespace | `PascalCase`, matches folder path | `EventManagement.Controllers` |
+| Class / struct / record | `PascalCase` | `BookingsController` |
+| Interface | `I` prefix + `PascalCase` | `IStorageService` |
+| Method | `PascalCase` | `GetCurrentUserIdAsync` |
+| Public property | `PascalCase` | `CheckInToken` |
+| Private field | `_camelCase` | `_db`, `_resolver` |
+| Local variable | `camelCase` | `confirmedCount`, `userId` |
+| Constant | `PascalCase` (class-level) or `UPPER_SNAKE` (file-scoped) | `RoleAdmin`, `StatusConfirmed` |
+| Async method | Suffix `Async` | `CreateBookingAsync` |
+| DTO / request / response | Suffix with role: `Request`, `Response`, `Dto` | `CreateEventRequest`, `BookingResponse` |
+
+### File & Folder Layout
+
+```
+backend/EventManagement/
+├── Controllers/      # One file per controller
+├── DTOs/             # Request/response shapes; group by domain (EventDtos.cs, BookingDtos.cs …)
+├── Models/           # EF Core entity classes; one file per entity
+├── Services/         # Business logic / infrastructure abstractions
+├── Middleware/       # Custom ASP.NET Core middleware
+├── Data/             # AppDbContext and migrations
+└── Program.cs        # Composition root — DI registrations and pipeline setup
+```
+
+- One class per file.
+- File name matches the primary type inside it.
+- Place migrations in `Data/Migrations/` and never hand-edit them.
+
+### Controllers
+
+- Inherit from `AppControllerBase`.
+- Declare the route at class level with `[Route("api/<resource>")]`.
+- Use primary constructor injection; do not assign to private fields unless the service needs to be used in multiple methods that cannot share the constructor-injected scope.
+- Keep action methods thin: validate input → load data → apply business rule → persist → return DTO. Extract non-trivial logic to a private helper or service.
+- Private helpers that build queries or apply filters are prefixed with `Apply` (e.g., `ApplyVisibilityFilter`).
+- Constant strings shared across action methods (roles, statuses) go at the top of the class as `private const string`.
+- Use section-divider comments (`// ── Section Name ──`) to group related action methods.
+
+```csharp
+// Good
+[HttpGet("{id}")]
+public async Task<IActionResult> GetById(int id)
+{
+    var ev = await db.Events
+        .Include(e => e.Category)
+        .FirstOrDefaultAsync(e => e.Id == id);
+
+    if (ev is null) return NotFound();
+    return Ok(MapToResponse(ev));
+}
+```
+
+### DTOs
+
+- Use C# `record` types for immutable request/response shapes.
+- Group related records in a single `*Dtos.cs` file (e.g., all booking DTOs in `BookingDtos.cs`).
+- Use nullable reference types (`string?`) to signal optional fields.
+- Validate required fields with `[Required]` and range constraints with `[Range]` on request DTOs.
+
+```csharp
+public record CreateEventRequest(
+    [Required] string Title,
+    [Required] string Description,
+    [Required] string Location,
+    [Required] DateTime StartDate,
+    [Required] DateTime EndDate,
+    [Range(0, int.MaxValue)] decimal Price,
+    int? CategoryId
+);
+```
+
+### Models
+
+- Entities are plain C# classes with `{ get; set; }` properties.
+- Navigation properties are declared at the bottom of the class, after scalar properties.
+- Use `int` for primary keys; use `Guid` only for tokens that must be globally unique (e.g., `CheckInToken`).
+- Required string navigation properties are initialised with `= null!;` to satisfy nullable analysis without unnecessary null-checks in business logic.
+
+### Services
+
+- Define an interface (`IFooService`) for every service that has more than one implementation or that needs to be swapped out in tests.
+- Register services in `Program.cs`; do not use service locator pattern.
+- Background services extend `BackgroundService` and override `ExecuteAsync`.
+
+### Tests (Backend)
+
+- Test class per controller or feature area (e.g., `BookingsControllerTests`).
+- Each test class uses its own `CustomWebApplicationFactory` instance — never share state across test classes.
+- Use `IAsyncLifetime.InitializeAsync` to seed prerequisite data.
+- Helper methods on `ApiClient` encapsulate repeated HTTP calls; keep test bodies focused on assertions.
+- Test method names follow `MethodName_Scenario_ExpectedResult`:
+  ```
+  CreateBooking_WhenEventAtCapacity_Returns409
+  CancelBooking_WithinSevenDays_Returns400
+  ```
+- Do not mock `AppDbContext` or HTTP clients; rely on the in-memory SQLite database.
+
+---
+
+## Frontend — TypeScript / React
+
+### Naming (TS)
+
+| Construct | Convention | Example |
+|---|---|---|
+| React component | `PascalCase` | `EventCard`, `NotificationBell` |
+| Hook | `use` prefix + `PascalCase` | `useDebounce`, `useMyFavoriteIds` |
+| Regular function | `camelCase` | `formatCurrency`, `applyVisibilityFilter` |
+| Variable / param | `camelCase` | `spotsLeft`, `userId` |
+| Constant (module-level) | `UPPER_SNAKE_CASE` | `CATEGORY_GRADIENTS` |
+| TypeScript type / interface | `PascalCase` | `Event`, `BookingResponse` |
+| File — component | `PascalCase.tsx` | `EventCard.tsx` |
+| File — hook / utility | `camelCase.ts` | `useDebounce.ts`, `utils.ts` |
+| File — API module | `camelCase.ts` | `bookings.ts`, `events.ts` |
+
+### File & Folder Layout
+
+```
+frontend/src/
+├── api/              # TanStack Query hooks + axios calls, one file per domain
+├── components/       # Shared, reusable components (no page-specific logic)
+│   ├── ui/           # shadcn/ui primitives (generated; do not edit unless extending)
+│   └── aceternity/   # Third-party animated components
+├── features/         # Feature-scoped components not reusable outside their domain
+│   ├── auth/
+│   ├── events/
+│   └── organizer/
+├── hooks/            # Custom React hooks
+├── layouts/          # Route layout wrappers (RootLayout, AuthLayout)
+├── lib/              # Pure utilities and third-party configuration
+├── pages/            # One file per route; thin — delegates to features/components
+├── routes/           # Router definition and protected-route guards
+├── stores/           # Zustand stores
+├── types/            # Shared TypeScript types (index.ts)
+└── main.tsx          # Entry point
+```
+
+### Components
+
+- **One component per file.** Private sub-components used only within that file may co-locate at the top of the same file.
+- Export named, not default:
+  ```tsx
+  // Good
+  export function EventCard({ event }: Props) { … }
+
+  // Avoid
+  export default function EventCard(…) { … }
+  ```
+- Define a local `interface Props` (or `type Props`) above the component. Do not inline types in the function signature when they are non-trivial.
+- Handlers are defined as named functions inside the component — not inline arrow functions passed to JSX — when they contain more than one statement.
+- Keep JSX readable: extract conditional rendering into a named variable when the inline ternary would span more than one line.
+- Use `cn()` from `@/lib/utils` for conditional class merging — do not concatenate class strings manually.
+
+```tsx
+// Good
+const pill = isAlmostFull
+  ? { label: 'Almost full', classes: '…' }
+  : isStartingSoon
+  ? { label: 'Starts soon', classes: '…' }
+  : null
+
+// Avoid inline ternary chains in JSX
+```
+
+### API Layer
+
+- Each file in `src/api/` owns one domain (e.g., `events.ts` for all event-related calls).
+- Export TanStack Query hooks (`useQuery`, `useMutation`) rather than raw fetch functions — pages and components call hooks, not `axios` directly.
+- Query keys are defined as constants at the top of the file:
+  ```ts
+  const EVENTS_KEY = ['events'] as const
+  ```
+- Mutations call `queryClient.invalidateQueries` on success to keep cached data fresh.
+- The shared axios instance lives in `src/api/axios.ts`; do not create additional instances.
+
+### State Management
+
+- **Server state** (anything fetched from the API): TanStack Query only. Do not copy remote data into Zustand.
+- **Client/UI state** (auth session, modal open/closed, theme): Zustand only. Do not use `useState` for state that crosses component boundaries.
+- `useAuthStore` in `src/stores/authStore.ts` is the single source of truth for the current user. Read it with the hook inside React; use `useAuthStore.getState()` for access outside the React tree.
+
+### Styling
+
+- **Tailwind CSS** for all styling. Do not write custom CSS unless it cannot be expressed with Tailwind utilities.
+- Custom global styles belong in `src/index.css` inside the appropriate `@layer` block.
+- The design token palette (colours, radius, etc.) is defined as CSS variables in `src/index.css`. Use semantic tokens (`text-muted-foreground`, `bg-card`, `border`) rather than raw Tailwind colour scales wherever possible, so dark mode works automatically.
+- The project font is **Plus Jakarta Sans**. Do not introduce additional web fonts.
+- Dark mode is toggled via a `.dark` class on `<html>` (managed by `ThemeContext`). Avoid hard-coded light-only colours.
+- Responsive breakpoints follow Tailwind's defaults (`sm`, `md`, `lg`, `xl`). Design mobile-first.
+
+**Spacing and layout pattern:**
+```tsx
+// Prefer semantic spacing tokens
+<div className="flex flex-col gap-4 p-4">
+
+// Use cn() for conditional classes, not string interpolation
+<div className={cn('rounded-lg border', isActive && 'border-primary')}>
+```
+
+### Types
+
+- All shared types live in `src/types/index.ts`.
+- Use `type` for object shapes derived from API responses; use `interface` only when extension / declaration merging is needed.
+- Prefer `import type` for type-only imports to keep runtime bundles lean.
+- Do not use `any`; use `unknown` and narrow explicitly.
+
+---
+
+## Shared — Git & Files
+
+- **Trailing whitespace:** never. Configure your editor to strip it on save.
+- **Line endings:** LF (Unix). The `.gitattributes` file enforces this.
+- **File encoding:** UTF-8 without BOM.
+- **Max line length:** 120 characters for C#; no hard limit for TypeScript but keep JSX lines readable.
+- **Imports order (TypeScript):** external packages → internal absolute (`@/`) → relative (`./`). Use a blank line between groups.
+- **Dead code:** delete it rather than commenting it out. Git history is the undo button.


### PR DESCRIPTION
## What
Adds two new documentation files to `docs/`:
- `CONTRIBUTING.md` — organisation-wide contributor standards
- `STYLE_GUIDE.md` — coding conventions for both backend (C#) and frontend (TypeScript/React)

## Why
As the team grows, contributors need a single reference for how to name branches, format commits, structure PRs, conduct reviews, and write code that is consistent with the rest of the codebase.

## What's covered

### CONTRIBUTING.md
- Branch naming convention (`feat/`, `fix/`, `docs/`, etc. in kebab-case)
- Commit message format (Conventional Commits)
- PR title and description template
- Code review expectations (author and reviewer responsibilities)
- Testing requirements per change type
- Definition of Done checklist

### STYLE_GUIDE.md
- C# naming (PascalCase, camelCase, `_camelCase` for private fields, `Async` suffix, DTO suffixes)
- Backend file/folder layout and layer responsibilities
- Controller, DTO, Model, and Service patterns with examples
- Backend test naming and isolation rules
- TypeScript/React naming (`PascalCase` components, `use` prefix hooks, `UPPER_SNAKE` module constants)
- Frontend file/folder layout (pages, features, components, api, stores)
- Component export pattern (named exports), `cn()` usage, handler style
- API layer conventions (TanStack Query hooks, query key constants, invalidation)
- State management rules (server state → TanStack Query, client state → Zustand)
- Tailwind/CSS conventions (semantic tokens, dark mode, Plus Jakarta Sans font, mobile-first breakpoints)
- Shared rules (line endings, encoding, import order, no dead code)

## Testing
Documentation only — no code changes.