### PR TITLE
docs: improve contributing guide and add code of conduct

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, caste, colour, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+---
+
+## Our Standards
+
+**Examples of behaviour that contributes to a positive environment:**
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+**Examples of unacceptable behaviour:**
+
+- The use of sexualised language or imagery, and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information (physical or email address) without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+---
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behaviour. They will take appropriate and fair corrective action in response to any behaviour they deem inappropriate, threatening, offensive, or harmful.
+
+Maintainers have the right to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned with this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+---
+
+## Scope
+
+This Code of Conduct applies within all project spaces — including the repository, issues, pull requests, and any other forum used by the project — and also applies when an individual is representing the project in public spaces.
+
+---
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the project maintainers. All complaints will be reviewed and investigated promptly and fairly. All maintainers are obligated to respect the privacy and security of the reporter.
+
+---
+
+## Enforcement Guidelines
+
+Maintainers will follow these guidelines when determining consequences:
+
+### 1. Correction
+**Impact:** Use of inappropriate language or other unprofessional behaviour.
+**Consequence:** A private written warning with an explanation of the violation. A public apology may be requested.
+
+### 2. Warning
+**Impact:** A single incident or series of actions that violate community standards.
+**Consequence:** A warning with consequences for continued behaviour. No interaction with the people involved for a specified period. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+**Impact:** A serious violation of community standards, including sustained inappropriate behaviour.
+**Consequence:** A temporary ban from any interaction or public communication with the community for a specified period.
+
+### 4. Permanent Ban
+**Impact:** Demonstrating a pattern of violation of community standards, including sustained inappropriate behaviour, harassment, or aggression toward any individual.
+**Consequence:** A permanent ban from any public interaction within the community.
+
+---
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,13 +1,17 @@
 # Contributing Guide
 
+> Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
+> By participating in this project you agree to abide by its terms.
+
 ## Table of Contents
 1. [Getting Started](#getting-started)
-2. [Branch Naming](#branch-naming)
-3. [Commit Messages](#commit-messages)
-4. [Pull Requests](#pull-requests)
-5. [Code Review](#code-review)
-6. [Testing Requirements](#testing-requirements)
-7. [Definition of Done](#definition-of-done)
+2. [Finding Something to Work On](#finding-something-to-work-on)
+3. [Branch Naming](#branch-naming)
+4. [Commit Messages](#commit-messages)
+5. [Pull Requests](#pull-requests)
+6. [Code Review](#code-review)
+7. [Testing Requirements](#testing-requirements)
+8. [Definition of Done](#definition-of-done)
 
 ---
 
@@ -36,6 +40,15 @@
 
 ---
 
+## Finding Something to Work On
+
+- Browse issues labelled **`good first issue`**, **`help wanted`**, or **`documentation`** — these are deliberately kept approachable for new contributors.
+- Comment on the issue to say you'd like to work on it. This prevents two people solving the same problem in parallel.
+- If you have an idea that isn't captured in an existing issue, open a new issue with a brief proposal **before** writing code. This avoids wasted effort if the direction doesn't fit the project.
+- Documentation improvements and additional test coverage are always welcome and rarely require a proposal first.
+
+---
+
 ## Branch Naming
 
 Branches **must** follow this pattern:
@@ -57,7 +70,12 @@ Branches **must** follow this pattern:
 **Rules:**
 - Use **kebab-case** for the description (`feat/add-waitlist-notifications`, not `feat/AddWaitlistNotifications`).
 - Keep descriptions short — 3–5 words max.
-- Always branch off the latest `main`.
+- Always branch off the latest `main` and keep your branch up to date using rebase:
+  ```bash
+  git fetch origin
+  git rebase origin/main
+  ```
+  Prefer rebase over merge to keep a linear, readable history.
 
 **Examples:**
 ```
@@ -86,7 +104,9 @@ Follow the **Conventional Commits** specification.
 **Rules:**
 - Summary line: imperative mood, no capital first letter, no trailing period, ≤ 72 characters.
 - Body: wrap at 72 characters, explain the motivation and contrast with prior behaviour.
-- Use `BREAKING CHANGE:` in the footer when a public API or DB schema changes in a non-backwards-compatible way.
+- Breaking changes must be signalled in **both** ways:
+  - Append `!` after the type/scope in the summary: `feat(api)!: …`
+  - Add a `BREAKING CHANGE:` footer describing what broke and the migration path.
 
 **Examples:**
 ```
@@ -100,6 +120,11 @@ fix(auth): return 401 instead of 500 on expired JWT
 refactor(events): extract visibility filter into helper method
 
 chore: upgrade xUnit to 2.9 and fix test runner warnings
+
+feat(api)!: remove deprecated /v1/users endpoint
+
+BREAKING CHANGE: /v1/users is removed; all clients must migrate to
+/v2/users. The response shape is unchanged — only the path differs.
 ```
 
 ---
@@ -147,6 +172,12 @@ fix(bookings): prevent double-booking on concurrent requests
 
 - Keep PRs focused. One logical change per PR.
 - If a PR exceeds ~400 lines of meaningful diff, consider splitting it.
+
+### Merge Strategy
+
+We use **squash and merge** for most PRs. This collapses the branch into a single clean commit on `main` and keeps the history linear.
+
+Use **rebase and merge** only when every individual commit on the branch is meaningful and you want them preserved verbatim (e.g. a multi-step refactor where each step must be bisectable).
 
 ---
 


### PR DESCRIPTION
## What
Applies five improvements to `CONTRIBUTING.md` and adds a new `CODE_OF_CONDUCT.md`.

## Changes

| # | Change | File |
|---|---|---|
| 1 | Add `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1) | new file |
| 2 | Link Code of Conduct from the top of the contributing guide | `CONTRIBUTING.md` |
| 3 | Add **Finding Something to Work On** section (good first issue, proposal-first flow) | `CONTRIBUTING.md` |
| 4 | Clarify branch update strategy: `git rebase origin/main` preferred over merge | `CONTRIBUTING.md` |
| 5 | Document `feat!` / `fix!` breaking-change syntax alongside `BREAKING CHANGE:` footer | `CONTRIBUTING.md` |
| 6 | Add **Merge Strategy** section: squash-and-merge by default | `CONTRIBUTING.md` |

## Why
- A Code of Conduct is expected by nearly all active open-source projects and signals a safe, professional environment.
- The "Finding Something to Work On" section removes the most common friction point for new contributors.
- Rebase preference and squash-merge strategy make history easier to read and bisect.
- The `!` shorthand for breaking changes is the modern Conventional Commits standard and should be documented alongside the footer form.

## Testing
Documentation only — no code changes.