### PR TITLE
docs: address review feedback across all four documentation files

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -4,6 +4,10 @@ Base URL: `http://localhost:5266`
 
 All request/response bodies are JSON. Endpoints marked with `[Auth]` require a `Bearer` token in the `Authorization` header.
 
+All error responses follow the **ProblemDetails (RFC 7807)** format (`{ type, title, status, detail }`). Validation failures include an additional `errors` map.
+
+> **Rate limiting** — high-frequency write endpoints (bookings, reviews, check-in) are rate-limited in production. Clients that exceed the limit receive `429 Too Many Requests`.
+
 ---
 
 ## Table of Contents
@@ -394,7 +398,7 @@ Cancel a booking (sets status to `Cancelled`). Only the booking owner can cancel
 
 ### `POST /api/bookings/{id}/checkin` `[Auth]`
 
-Check in an attendee by booking ID. Only the event host or an admin can call this.
+Check in an attendee by booking ID. Suitable for internal/admin tooling where the booking ID is already known. Only the event host or an admin can call this.
 
 **Response `204 No Content`**
 **Response `400 Bad Request`** — booking is cancelled or already checked in.
@@ -403,9 +407,11 @@ Check in an attendee by booking ID. Only the event host or an admin can call thi
 
 ---
 
-### `GET /api/bookings/checkin/{token}` `[Auth]`
+### `GET /api/bookings/checkin/{token}`
 
-Look up booking information by QR token. Used by a host's QR scanner to preview an attendee before checking them in.
+Look up booking information by QR token. This is a **public endpoint** — no authentication is required — so that a scanner device can identify an attendee before the host confirms check-in.
+
+**Recommended flow:** call this first to display the attendee's details, then call `POST /api/bookings/checkin/{token}` (with auth) to mark attendance.
 
 **Response `200 OK`**
 ```json
@@ -425,7 +431,7 @@ Look up booking information by QR token. Used by a host's QR scanner to preview 
 
 ### `POST /api/bookings/checkin/{token}` `[Auth]`
 
-Check in an attendee via their QR token. Only the event host or an admin can call this.
+Mark an attendee as attended via their QR token. **Preferred for on-site check-in** (scanner devices encode the token, not the booking ID). Only the event host or an admin can call this.
 
 **Response `204 No Content`**
 **Response `400 Bad Request`** — booking is cancelled or already checked in.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -209,6 +209,27 @@ Each controller owns exactly one aggregate or cross-cutting concern:
 | Resource not found | 404 Not Found |
 | Duplicate resource | 409 Conflict |
 
+All non-2xx responses use the **ProblemDetails (RFC 7807)** format:
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc7807",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "This event is fully booked."
+}
+```
+
+Validation errors (model binding failures) use `ValidationProblemDetails`, which adds an `errors` map.
+
+### Pagination
+
+List endpoints that can return large result sets support cursor-based pagination via `page` and `pageSize` query parameters (default `pageSize=12`, maximum `pageSize=100`). Responses include a top-level count of total matching records so clients can calculate page counts.
+
+```
+GET /api/events?page=2&pageSize=20
+```
+
 ### Visibility Rules for Events
 
 ```

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -38,13 +38,17 @@ Maintainers have the right to remove, edit, or reject comments, commits, code, i
 
 ## Scope
 
-This Code of Conduct applies within all project spaces — including the repository, issues, pull requests, and any other forum used by the project — and also applies when an individual is representing the project in public spaces.
+This Code of Conduct applies within all project spaces — including the repository, issues, pull requests, and any other forum used by the project — and also applies when an individual is officially representing the project in public spaces (e.g., posting on behalf of the project on social media, speaking at an event, or acting as a designated representative). Behaviour outside project spaces that materially harms other community members or the reputation of the project may also be subject to enforcement at maintainer discretion.
 
 ---
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the project maintainers. All complaints will be reviewed and investigated promptly and fairly. All maintainers are obligated to respect the privacy and security of the reporter.
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the project maintainer directly:
+
+**Email:** yangjiapeng6888@gmail.com
+
+Reports may be submitted anonymously if preferred. All complaints will be reviewed and investigated promptly and fairly. All maintainers are obligated to respect the privacy and security of the reporter, and no personal details will be disclosed to the subject of a report without the reporter's consent.
 
 ---
 
@@ -58,7 +62,7 @@ Maintainers will follow these guidelines when determining consequences:
 
 ### 2. Warning
 **Impact:** A single incident or series of actions that violate community standards.
-**Consequence:** A warning with consequences for continued behaviour. No interaction with the people involved for a specified period. Violating these terms may lead to a temporary or permanent ban.
+**Consequence:** A formal warning, which may include a temporary restriction on interaction with the affected individuals for a specified period. Violating these terms may lead to a temporary or permanent ban.
 
 ### 3. Temporary Ban
 **Impact:** A serious violation of community standards, including sustained inappropriate behaviour.

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -46,7 +46,7 @@ Conventions for both the **ASP.NET Core backend** (C#) and the **React frontend*
 | Public property | `PascalCase` | `CheckInToken` |
 | Private field | `_camelCase` | `_db`, `_resolver` |
 | Local variable | `camelCase` | `confirmedCount`, `userId` |
-| Constant | `PascalCase` (class-level) or `UPPER_SNAKE` (file-scoped) | `RoleAdmin`, `StatusConfirmed` |
+| Constant | `PascalCase` | `RoleAdmin`, `StatusConfirmed` |
 | Async method | Suffix `Async` | `CreateBookingAsync` |
 | DTO / request / response | Suffix with role: `Request`, `Response`, `Dto` | `CreateEventRequest`, `BookingResponse` |
 
@@ -71,11 +71,12 @@ backend/EventManagement/
 
 - Inherit from `AppControllerBase`.
 - Declare the route at class level with `[Route("api/<resource>")]`.
-- Use primary constructor injection; do not assign to private fields unless the service needs to be used in multiple methods that cannot share the constructor-injected scope.
+- Use primary constructor injection for simple dependency injection. If a constructor requires non-trivial initialisation logic or argument validation, use a traditional constructor body instead.
 - Keep action methods thin: validate input → load data → apply business rule → persist → return DTO. Extract non-trivial logic to a private helper or service.
 - Private helpers that build queries or apply filters are prefixed with `Apply` (e.g., `ApplyVisibilityFilter`).
 - Constant strings shared across action methods (roles, statuses) go at the top of the class as `private const string`.
 - Use section-divider comments (`// ── Section Name ──`) to group related action methods.
+- Return errors using `Problem()` (or `ValidationProblem()` for model errors) so that all error responses follow the [ProblemDetails (RFC 7807)](https://datatracker.ietf.org/doc/html/rfc7807) format — this keeps client error handling uniform and Swagger-friendly.
 
 ```csharp
 // Good
@@ -89,6 +90,12 @@ public async Task<IActionResult> GetById(int id)
     if (ev is null) return NotFound();
     return Ok(MapToResponse(ev));
 }
+
+// Good — ProblemDetails for business rule violations
+if (event.IsSoldOut)
+    return Problem(
+        statusCode: StatusCodes.Status400BadRequest,
+        detail: "This event is fully booked.");
 ```
 
 ### DTOs
@@ -213,6 +220,7 @@ const pill = isAlmostFull
   ```
 - Mutations call `queryClient.invalidateQueries` on success to keep cached data fresh.
 - The shared axios instance lives in `src/api/axios.ts`; do not create additional instances.
+- For components already wrapped in a `<Suspense>` boundary, prefer `useSuspenseQuery` over `useQuery` to remove manual `isLoading` handling. This is the direction recommended by TanStack Query v5 and React 19+.
 
 ### State Management
 


### PR DESCRIPTION
## What
Applies all review-suggested improvements across `CODE_OF_CONDUCT.md`, `STYLE_GUIDE.md`, `ARCHITECTURE.md`, and `API_REFERENCE.md`.

## Changes by file

### `CODE_OF_CONDUCT.md`
- **Contact email** added to Enforcement (`yangjiapeng6888@gmail.com`) so reporters know exactly how to reach a maintainer
- **Anonymous reporting** option explicitly noted
- **Scope** expanded to cover external representation and off-platform behaviour that harms the community
- **Warning level** reworded — removed the ambiguous "No interaction with the people involved" phrasing and replaced with clearer "temporary restriction on interaction"

### `STYLE_GUIDE.md`
- **Constant naming unified to `PascalCase`** — removed the dual `PascalCase` / `UPPER_SNAKE` option that was causing inconsistency; aligns with Roslyn analyzers and Microsoft conventions
- **Primary constructor scope clarified** — recommended for simple DI; traditional constructor preferred when initialisation logic or validation is needed
- **ProblemDetails recommendation added** to Controllers — `Problem()` / `ValidationProblem()` helpers keep error responses uniform and Swagger-friendly
- **`useSuspenseQuery` direction noted** in API Layer — forward-looking note for React 19+ / TanStack Query v5 Suspense pattern

### `ARCHITECTURE.md`
- **ProblemDetails response format** documented after the HTTP status code table, with a JSON example
- **Pagination section added** documenting `page` / `pageSize` parameters

### `API_REFERENCE.md`
- **ProblemDetails and rate limiting notes** added to the file header
- **`GET /api/bookings/checkin/{token}` corrected** — removed the erroneous `[Auth]` tag; this is a public endpoint by design (scanner devices have no token)
- **Two check-in paths clarified** — token route is preferred for on-site scanning; ID route is for internal/admin tooling

## Testing
Documentation only — no code changes.